### PR TITLE
Remove Version If Statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,9 @@ vpDiscordRPCx64 is unofficial plugin for [J.A.C.K](https://jack.hlfx.ru/en/). Ac
 
  1. Download archive from [Releases](https://github.com/ScriptedSnark/vpDiscordRPCx64/releases/latest)
  2. Unpack archive
- 3. If you use 64-bit version of free J.A.C.K, move `x64/free/vpDiscordRPCx64.dll` to `J.A.C.K/plugins`
+ 3. If you use a 64-bit version of J.A.C.K, move `x64/vpDiscordRPCx64.dll` to `J.A.C.K/plugins`
 
-    If you use 32-bit version of free J.A.C.K, move `x86/free/vpDiscordRPCx86.dll` to `J.A.C.K/plugins`
-
-    If you use 64-bit version of Steam J.A.C.K, move `x64/steam/vpDiscordRPCx64.dll` to `J.A.C.K/plugins`
+    If you use a 32-bit version of J.A.C.K, move `x86/vpDiscordRPCx86.dll` to `J.A.C.K/plugins`
 
 4. That's it! Run J.A.C.K and check that Discord RPC is working.
 

--- a/vpDiscordRPCx64.sln
+++ b/vpDiscordRPCx64.sln
@@ -1,32 +1,26 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.33027.164
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33205.214
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "vpDiscordRPCx64", "vpDiscordRPCx64\vpDiscordRPCx64.vcxproj", "{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Free Debug|x64 = Free Debug|x64
-		Free Debug|x86 = Free Debug|x86
-		Free Release|x64 = Free Release|x64
-		Free Release|x86 = Free Release|x86
-		Retail Release|x64 = Retail Release|x64
-		Retail Release|x86 = Retail Release|x86
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}.Free Debug|x64.ActiveCfg = Debug|x64
-		{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}.Free Debug|x64.Build.0 = Debug|x64
-		{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}.Free Debug|x86.ActiveCfg = Debug|Win32
-		{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}.Free Debug|x86.Build.0 = Debug|Win32
-		{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}.Free Release|x64.ActiveCfg = Release|x64
-		{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}.Free Release|x64.Build.0 = Release|x64
-		{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}.Free Release|x86.ActiveCfg = Release|Win32
-		{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}.Free Release|x86.Build.0 = Release|Win32
-		{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}.Retail Release|x64.ActiveCfg = Retail Release|x64
-		{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}.Retail Release|x64.Build.0 = Retail Release|x64
-		{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}.Retail Release|x86.ActiveCfg = Retail Release|Win32
-		{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}.Retail Release|x86.Build.0 = Retail Release|Win32
+		{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}.Debug|x64.ActiveCfg = Debug|x64
+		{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}.Debug|x64.Build.0 = Debug|x64
+		{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}.Debug|x86.ActiveCfg = Debug|Win32
+		{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}.Debug|x86.Build.0 = Debug|Win32
+		{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}.Release|x64.ActiveCfg = Release|x64
+		{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}.Release|x64.Build.0 = Release|x64
+		{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}.Release|x86.ActiveCfg = Release|Win32
+		{9C5F1E85-C7E7-4AC6-BAD1-BC67DCBE57C1}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/vpDiscordRPCx64/vp_main.cpp
+++ b/vpDiscordRPCx64/vp_main.cpp
@@ -5,12 +5,6 @@
 
 #include "includes.h"
 
-#ifdef RETAIL
-constexpr int JACK_PLUGINS_VER = 100;
-#else
-constexpr int JACK_PLUGINS_VER = 10;
-#endif
-
 //-----------------------------------------------------------------------------
 // Initialize Discord RPC
 //-----------------------------------------------------------------------------
@@ -27,9 +21,6 @@ void InitPlugin()
 #ifdef _M_X64
 extern "C" int EXPORT vpMain(unsigned long long* Src, int version) // 64-bit implementation
 {
-	if (version != JACK_PLUGINS_VER)
-		return JACK_PLUGINS_VER; // from IDA pseudocode
-
 	// TODO: memcpy(&unk_18001B4B0, Src, *Src); | other things for this
 
 	setlocale(LC_ALL, "C");
@@ -43,9 +34,6 @@ extern "C" int EXPORT vpMain(DWORD* Src, int version) // 32-bit implementation
 {
 	if (*Src < 720u) // 0x2D0u -> 720u
 		return -1;
-
-	if (version != JACK_PLUGINS_VER)
-		return JACK_PLUGINS_VER;
 
 	//memcpy(&unk_100170D8, Src, *Src);
 


### PR DESCRIPTION
This if statement is unneeded; it just makes our lives harder and users' by having to choose the right dll for their version. I have tested, the plugin works fine without the statement.